### PR TITLE
Support ATSC-style channel numbers, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ virtual enviroment
 ```virtualenv venv```
 
 Activate the virtual enviroment
-```. bin/venv/activate```
+```. venv/bin/activate```
 
 Install the requirements
 ```pip install -r requirements.txt```

--- a/README.md
+++ b/README.md
@@ -1,28 +1,43 @@
 tvhProxy
 ========
 
-An small flask app to proxy requests between Plex Media Server and Tvheadend
+A small flask app to proxy requests between Plex Media Server and Tvheadend.
 
+#### tvhProxy configuration
+1. In tvhProxy.py configure options as per your setup.
+2. Create a virtual enviroment: ```$ virtualenv venv```
+3. Activate the virtual enviroment: ```$ . venv/bin/activate```
+4. Install the requirements: ```$ pip install -r requirements.txt```
+5. Finally run the app with: ```$ python tvhProxy.py```
 
-In tvhProxy.py configure options as per your setup, then create a 
-virtual enviroment
-```virtualenv venv```
+#### Virtual host configuration
+1. Add an entry to /etc/hosts to use as a virtual host:
 
-Activate the virtual enviroment
-```. venv/bin/activate```
+    ```
+127.0.0.1	localhost
+127.0.0.1	tvhproxy
+    ```
+2. Configure a web server virtual host to listen for PMS on port 80 and proxy to tvhProxy on port 5004.
+    
+    Nginx example:
 
-Install the requirements
-```pip install -r requirements.txt```
+    ```
+    server {
+        listen       80;
+        server_name  tvhproxy;
+        location / {
+            proxy_pass http://127.0.0.1:5004;
+        }
+    }
+    ```
 
-Finally run the app with
-```python tvhProxy.py```
+#### systemd service configuration
+A startup script for Ubuntu can be found in tvhProxy.service (change paths to your setup), install with:
 
-An startup script for Ubuntu can be found in tvhProxy.service (change 
-paths to your setup), install with
-```
-cp tvhProxy.service /etc/systemd/system/tvhProxy.service
-systemctl daemon-reload
-systemctl enable tvhProxy.service
-```
+    $ sudo cp tvhProxy.service /etc/systemd/system/tvhProxy.service
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable tvhProxy.service
+    $ sudo systemctl start tvhProxy.service
 
-When in PMS setting the DVR up, use the url <ip/localhost>:5004
+#### Plex configuration
+Enter the virtual host name as the DVR device address (port not required): ```tvhproxy```

--- a/tvhProxy.py
+++ b/tvhProxy.py
@@ -70,7 +70,7 @@ def stream(channel):
     duration += time.time()
 
     for c in _get_channels():
-        if c['number'] == int(channel):
+        if float(c['number']) == float(channel):
             url = '%s%s%s' % (config['tvhURL'], '/stream/channel/', c['uuid'])
 
     if not url:


### PR DESCRIPTION
ATSC channels are in decimal format to allow for sub channels for each station (channel 7.1, 7.2, 7.3, etc) - this fixes the following crash when these channels are evaluated as int:

```
ERROR in app: Exception on /auto/v7.4 [GET]
Traceback (most recent call last):
[...]
  File "tvhProxy.py", line 75, in stream
    if c['number'] == int(channel):
ValueError: invalid literal for int() with base 10: '7.4'
```
