### PR TITLE
Fix for device not enabled in settings

### DIFF
--- a/templates/device.xml
+++ b/templates/device.xml
@@ -1,0 +1,16 @@
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+    <specVersion>
+        <major>1</major>
+        <minor>0</minor>
+    </specVersion>
+    <URLBase>{{ data.BaseURL }}</URLBase>
+    <device>
+        <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
+        <friendlyName>{{ data.FriendlyName }}</friendlyName>
+        <manufacturer>{{ data.Manufacturer }}</manufacturer>
+        <modelName>{{ data.ModelNumber }}</modelName>
+        <modelNumber>{{ data.ModelNumber }}</modelNumber>
+        <serialNumber></serialNumber>
+        <UDN>uuid:{{ data.DeviceID }}</UDN>
+    </device>
+</root>

--- a/tvhProxy.py
+++ b/tvhProxy.py
@@ -4,7 +4,7 @@ import time
 import os
 import requests
 from gevent.pywsgi import WSGIServer
-from flask import Flask, Response, request, jsonify, abort, render_template
+from flask import Flask, Response, request, jsonify, abort, render_template, json
 
 app = Flask(__name__)
 
@@ -19,21 +19,22 @@ config = {
     'streamProfile': os.environ.get('TVH_PROFILE') or 'pass'  # specifiy a stream profile that you want to use for adhoc transcoding in tvh, e.g. mp4
 }
 
+discoverData = {
+    'FriendlyName': 'tvhProxy',
+    'Manufacturer' : 'Silicondust',
+    'ModelNumber': 'HDTC-2US',
+    'FirmwareName': 'hdhomeruntc_atsc',
+    'TunerCount': int(config['tunerCount']),
+    'FirmwareVersion': '20150826',
+    'DeviceID': '12345678',
+    'DeviceAuth': 'test1234',
+    'BaseURL': '%s' % config['tvhProxyURL'],
+    'LineupURL': '%s/lineup.json' % config['tvhProxyURL']
+}
 
 @app.route('/discover.json')
 def discover():
-    return jsonify({
-        'FriendlyName': 'tvhProxy',
-        'Manufacturer' : 'Silicondust',
-        'ModelNumber': 'HDTC-2US',
-        'FirmwareName': 'hdhomeruntc_atsc',
-        'TunerCount': int(config['tunerCount']),
-        'FirmwareVersion': '20150826',
-        'DeviceID': '12345678',
-        'DeviceAuth': 'test1234',
-        'BaseURL': '%s' % config['tvhProxyURL'],
-        'LineupURL': '%s/lineup.json' % config['tvhProxyURL']
-    })
+    return jsonify(discoverData)
 
 
 @app.route('/lineup_status.json')
@@ -69,7 +70,8 @@ def lineup_post():
 @app.route('/')
 @app.route('/device.xml')
 def device():
-    return render_template('device.xml',data = discover()),{'Content-Type': 'application/xml'}
+    data = json.dumps(discoverData, indent=2, separators=(', ', ': '))
+    return render_template('device.xml',data = data),{'Content-Type': 'application/xml'}
 
 
 def _get_channels():

--- a/tvhProxy.py
+++ b/tvhProxy.py
@@ -4,7 +4,7 @@ import time
 import os
 import requests
 from gevent.pywsgi import WSGIServer
-from flask import Flask, Response, request, jsonify, abort, render_template, json
+from flask import Flask, Response, request, jsonify, abort, render_template
 
 app = Flask(__name__)
 
@@ -19,22 +19,21 @@ config = {
     'streamProfile': os.environ.get('TVH_PROFILE') or 'pass'  # specifiy a stream profile that you want to use for adhoc transcoding in tvh, e.g. mp4
 }
 
-discoverData = {
-    'FriendlyName': 'tvhProxy',
-    'Manufacturer' : 'Silicondust',
-    'ModelNumber': 'HDTC-2US',
-    'FirmwareName': 'hdhomeruntc_atsc',
-    'TunerCount': int(config['tunerCount']),
-    'FirmwareVersion': '20150826',
-    'DeviceID': '12345678',
-    'DeviceAuth': 'test1234',
-    'BaseURL': '%s' % config['tvhProxyURL'],
-    'LineupURL': '%s/lineup.json' % config['tvhProxyURL']
-}
 
 @app.route('/discover.json')
 def discover():
-    return jsonify(discoverData)
+    return jsonify({
+        'FriendlyName': 'tvhProxy',
+        'Manufacturer' : 'Silicondust',
+        'ModelNumber': 'HDTC-2US',
+        'FirmwareName': 'hdhomeruntc_atsc',
+        'TunerCount': int(config['tunerCount']),
+        'FirmwareVersion': '20150826',
+        'DeviceID': '12345678',
+        'DeviceAuth': 'test1234',
+        'BaseURL': '%s' % config['tvhProxyURL'],
+        'LineupURL': '%s/lineup.json' % config['tvhProxyURL']
+    })
 
 
 @app.route('/lineup_status.json')
@@ -70,8 +69,7 @@ def lineup_post():
 @app.route('/')
 @app.route('/device.xml')
 def device():
-    data = json.dumps(discoverData, indent=2, separators=(', ', ': '))
-    return render_template('device.xml',data = data),{'Content-Type': 'application/xml'}
+    return render_template('device.xml',data = discover()),{'Content-Type': 'application/xml'}
 
 
 def _get_channels():

--- a/tvhProxy.py
+++ b/tvhProxy.py
@@ -4,7 +4,7 @@ import time
 import os
 import requests
 from gevent.pywsgi import WSGIServer
-from flask import Flask, Response, request, jsonify, abort
+from flask import Flask, Response, request, jsonify, abort, render_template
 
 app = Flask(__name__)
 
@@ -24,6 +24,7 @@ config = {
 def discover():
     return jsonify({
         'FriendlyName': 'tvhProxy',
+        'Manufacturer' : 'Silicondust',
         'ModelNumber': 'HDTC-2US',
         'FirmwareName': 'hdhomeruntc_atsc',
         'TunerCount': int(config['tunerCount']),
@@ -64,6 +65,11 @@ def lineup():
 @app.route('/lineup.post')
 def lineup_post():
     return ''
+
+@app.route('/')
+@app.route('/device.xml')
+def device():
+    return render_template('device.xml',data = discover()),{'Content-Type': 'application/xml'}
 
 
 def _get_channels():

--- a/tvhProxy.py
+++ b/tvhProxy.py
@@ -19,21 +19,22 @@ config = {
     'streamProfile': os.environ.get('TVH_PROFILE') or 'pass'  # specifiy a stream profile that you want to use for adhoc transcoding in tvh, e.g. mp4
 }
 
+discoverData = {
+    'FriendlyName': 'tvhProxy',
+    'Manufacturer' : 'Silicondust',
+    'ModelNumber': 'HDTC-2US',
+    'FirmwareName': 'hdhomeruntc_atsc',
+    'TunerCount': int(config['tunerCount']),
+    'FirmwareVersion': '20150826',
+    'DeviceID': '12345678',
+    'DeviceAuth': 'test1234',
+    'BaseURL': '%s' % config['tvhProxyURL'],
+    'LineupURL': '%s/lineup.json' % config['tvhProxyURL']
+}
 
 @app.route('/discover.json')
 def discover():
-    return jsonify({
-        'FriendlyName': 'tvhProxy',
-        'Manufacturer' : 'Silicondust',
-        'ModelNumber': 'HDTC-2US',
-        'FirmwareName': 'hdhomeruntc_atsc',
-        'TunerCount': int(config['tunerCount']),
-        'FirmwareVersion': '20150826',
-        'DeviceID': '12345678',
-        'DeviceAuth': 'test1234',
-        'BaseURL': '%s' % config['tvhProxyURL'],
-        'LineupURL': '%s/lineup.json' % config['tvhProxyURL']
-    })
+    return jsonify(discoverData)
 
 
 @app.route('/lineup_status.json')
@@ -69,7 +70,7 @@ def lineup_post():
 @app.route('/')
 @app.route('/device.xml')
 def device():
-    return render_template('device.xml',data = discover()),{'Content-Type': 'application/xml'}
+    return render_template('device.xml',data = discoverData),{'Content-Type': 'application/xml'}
 
 
 def _get_channels():


### PR DESCRIPTION
Although the variables with the device.xml are not populated correctly, this fix still resolves the non enabled setting of the device in plex settings